### PR TITLE
Expanded recommended reading and added some history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ _build/
 
 # Generated figures (copied to docs/_images/ by Sphinx during build)
 content/figures/
-content/ds006185
-ds006185
+content/ds006185/
+ds006185/
 
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ _build/
 
 # Generated figures (copied to docs/_images/ by Sphinx during build)
 content/figures/
+content/ds006185
+ds006185
 
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ _build/
 content/figures/
 content/ds006185/
 ds006185/
+content/ds006185
+ds006185
 
 .DS_Store
 

--- a/content/Recommended_Reading.md
+++ b/content/Recommended_Reading.md
@@ -10,11 +10,64 @@ kernelspec:
   name: python3
 ---
 
-# Recommended Reading
+# Recommended Reading & History
 
-## Journal articles describing multi-echo methods
+## The first two decades of multi-echo fMRI
 
-{cite:t}`POSSE2012665` includes an historical overview of multi-echo acquisition and research.
-{cite:t}`KUNDU201759` is a review of multi-echo denoising with a focus on the MEICA algorithm.
-The appendix of {cite:t}`OLAFSSON201543` includes a good explanation of the math underlying MEICA denoising.
-The appendix of {cite:t}`dipasquale2017comparing` includes some recommendations for multi-echo acquisition.
+{cite:p}`POSSE2012665` includes an historical overview of multi-echo acquisition and research.
+Multi-echo fMRI is sometimes discussed as a newer method, but it's as old as fMRI.
+Much of this work set up the theory and empirical measurements that drive continued innovation in multi-echo methods.
+Early work trying to understand BOLD responses to neural activity used multi-echo sequences {cite:p}`menon19934-e70`.
+Multi-echo fMRI is effectively sampling the same frequency induced decay curve
+as in NMR spectroscopy, and some of the early work in this area called itself functional spectroscopy {cite:p}`hennig1994detection-075,speck1998functional-366`.
+
+{cite:p}`posse1999enhancement-176` built on much of this work to show how taking the weighted sum of multi-echoes can improve fMRI results over single-echo fMRI.
+{cite:p}`poser2006bold-bda` added and validated more ways to calculate the weighted sum across echoes to increase sensititivity to BOLD contrast.
+Poser's T2* weighting method is the default weighting used in {py:func}`tedana.combine.make_optcom` and other software and this weighted sum is sometimes called "Optimally Combined".
+Despite this method being called "optimal" research continues in comparing and validating echo combination options {cite:p}`heunis2021effects`.
+
+
+## ICA-based denoising
+
+{cite:p}`KUNDU201759` is a review of multi-echo denoising with a focus on the Multi-echo ICA (MEICA) algorithm.
+One challenge of using multi-echo data is that we are trying to fit noisy data to a line or a decay curve.
+While the overall data quality might increase, there is noise added by fit errors.
+On way to avoid fit errors is just to take the weighted sum across echoes, as highlighted in the previous section.
+Averaging signals with independent measurement noise with similar noise distributions,
+should always be net gain in data quality,
+but it doesn't take full advantage of the relationship between echoes.
+
+{cite:p}`buur2008extraction-629` evaluated and tested ICA and other data decomposition tools with the goal of identifying and removing non-T2* weighted signals with spatio-temporal structure.
+If the decomposition method separates the data into sources with more and less T2* contribution,
+then one can decay models within each source to get better estimates.
+{cite:p}`kundu2012differentiating-263,Kundu2013-po` built on this idea of using ICA to develop and share an algorithm,
+MEICA, that showed substantiable improvements in noise removal.
+The appendix of {cite:p}`OLAFSSON201543` includes a good explanation of the math underlying MEICA denoising.
+The appendix of {cite:p}`dipasquale2017comparing` includes some recommendations for multi-echo acquisition.
+
+## Broadening of multi-echo users and community
+
+While multi-echo fMRI is old, through the 2000's, it was mostly used by MRI physicists and methodology researchers.
+There are several reasons for this.
+MRI hardware and pulse sequences were too slow to collect a whole-brain fMRI volume in 2 seconds.
+Much of the earlier work used slabs of the brain or even a just a few slices.
+One could get most of cortex in 2 seconds using in-slice acceleration, but even then there was an additional challenge.
+Even thought collecting multi-echo data is a relatively minor tweak in standard fMRI pulse sequences,
+most pulse sequences that could be used to collect multi-echo fMRI data were research sequences that were
+passed researcher-to-researcher by request.
+None of the mainstream vendors distributed a multi-echo fMRI sequence that users who weren't MRI experts could just run.
+In the mid-2010's several things came together to address the above challenges.
+Simultaneous multi-slice acceleration {cite:p}`setsompop2012blipped-controlled-1a0` and improvements in hardware meant that it was possible to collect whole-brain multi-echo fMRI data with minimal compromises.
+Research sequences that included multi-echo acqusition started to get shared more widely.
+Of particular note, the CMRR Multi-band sequence that was used for the Human Connectome Project on Siemens scanners added multi-echo acqusition in 2014.
+While this was a research sequence, since it was widely accessible and used,
+it greatly expanded the number of researchers who could easily acquire multi-echo data.
+
+The growth in users was paralleled with a growth in community.
+Researchers from multiple sites came together to build [tedana](https://tedana.readthedocs.io)
+which is both a platform to run a range of methods that build on the MEICA approach,
+and community resources that make it easier for researchers to learn about and use
+multi-echo fMRI. The book is one product of this community work.
+
+
+

--- a/content/Recommended_Reading.md
+++ b/content/Recommended_Reading.md
@@ -21,42 +21,42 @@ Early work trying to understand BOLD responses to neural activity used multi-ech
 Multi-echo fMRI is effectively sampling the same frequency induced decay curve
 as in NMR spectroscopy, and some of the early work in this area called itself functional spectroscopy {cite:p}`hennig1994detection-075,speck1998functional-366`.
 
-{cite:p}`posse1999enhancement-176` built on much of this work to show how taking the weighted sum of multi-echoes can improve fMRI results over single-echo fMRI.
-{cite:p}`poser2006bold-bda` added and validated more ways to calculate the weighted sum across echoes to increase sensititivity to BOLD contrast.
+{cite:p}`posse1999enhancement-176` built on much of this work to show how taking the weighted sum of multiple echoes can improve fMRI results over single-echo fMRI.
+{cite:p}`poser2006bold-bda` added and validated more ways to calculate the weighted sum across echoes to increase sensitivity to BOLD contrast.
 Poser's T2* weighting method is the default weighting used in {py:func}`tedana.combine.make_optcom` and other software and this weighted sum is sometimes called "Optimally Combined".
-Despite this method being called "optimal" research continues in comparing and validating echo combination options {cite:p}`heunis2021effects`.
+Despite this method being called "optimal," research continues in comparing and validating echo combination options {cite:p}`heunis2021effects`.
 
 
 ## ICA-based denoising
 
-{cite:p}`KUNDU201759` is a review of multi-echo denoising with a focus on the Multi-echo ICA (MEICA) algorithm.
-One challenge of using multi-echo data is that we are trying to fit noisy data to a line or a decay curve.
+{cite:p}`KUNDU201759` is a review of multi-echo denoising with a focus on the Multi-Echo ICA (MEICA) algorithm.
+One challenge of using multi-echo data is that we are trying to fit a line or decay curve to noisy data.
 While the overall data quality might increase, there is noise added by fit errors.
-On way to avoid fit errors is just to take the weighted sum across echoes, as highlighted in the previous section.
-Averaging signals with independent measurement noise with similar noise distributions,
-should always be net gain in data quality,
+One way to avoid fit errors is just to take the weighted sum across echoes, as highlighted in the previous section.
+Averaging signals with independent measurement noise and similar noise distributions
+should always be a net gain in data quality,
 but it doesn't take full advantage of the relationship between echoes.
 
 {cite:p}`buur2008extraction-629` evaluated and tested ICA and other data decomposition tools with the goal of identifying and removing non-T2* weighted signals with spatio-temporal structure.
 If the decomposition method separates the data into sources with more and less T2* contribution,
-then one can decay models within each source to get better estimates.
+then one can fit decay models within each source to get better estimates.
 {cite:p}`kundu2012differentiating-263,Kundu2013-po` built on this idea of using ICA to develop and share an algorithm,
-MEICA, that showed substantiable improvements in noise removal.
+MEICA, that showed substantial improvements in noise removal.
 The appendix of {cite:p}`OLAFSSON201543` includes a good explanation of the math underlying MEICA denoising.
 The appendix of {cite:p}`dipasquale2017comparing` includes some recommendations for multi-echo acquisition.
 
 ## Broadening of multi-echo users and community
 
-While multi-echo fMRI is old, through the 2000's, it was mostly used by MRI physicists and methodology researchers.
+While multi-echo fMRI is old, through the 2000s it was mostly used by MRI physicists and methodology researchers.
 There are several reasons for this.
 MRI hardware and pulse sequences were too slow to collect a whole-brain fMRI volume in 2 seconds.
 Much of the earlier work used slabs of the brain or even a just a few slices.
 One could get most of cortex in 2 seconds using in-slice acceleration, but even then there was an additional challenge.
-Even thought collecting multi-echo data is a relatively minor tweak in standard fMRI pulse sequences,
+Even though collecting multi-echo data is a relatively minor tweak in standard fMRI pulse sequences,
 most pulse sequences that could be used to collect multi-echo fMRI data were research sequences that were
 passed researcher-to-researcher by request.
 None of the mainstream vendors distributed a multi-echo fMRI sequence that users who weren't MRI experts could just run.
-In the mid-2010's several things came together to address the above challenges.
+In the mid-2010s several things came together to address the above challenges.
 Simultaneous multi-slice acceleration {cite:p}`setsompop2012blipped-controlled-1a0` and improvements in hardware meant that it was possible to collect whole-brain multi-echo fMRI data with minimal compromises.
 Research sequences that included multi-echo acqusition started to get shared more widely.
 Of particular note, the CMRR Multi-band sequence that was used for the Human Connectome Project on Siemens scanners added multi-echo acqusition in 2014.

--- a/content/references.bib
+++ b/content/references.bib
@@ -1,53 +1,35 @@
-@article{power2018ridding,
-	title={Ridding fMRI data of motion-related influences: Removal of signals with distinct spatial and physical bases in multiecho data},
-	author={Power, Jonathan D and Plitt, Mark and Gotts, Stephen J and Kundu, Prantik and Voon, Valerie and Bandettini, Peter A and Martin, Alex},
-	journal={Proceedings of the National Academy of Sciences},
-	volume={115},
-	number={9},
-	pages={E2105--E2114},
-	year={2018},
-	publisher={National Acad Sciences}
+@article{berger2002does,
+  title={How does it work?: Magnetic resonance imaging},
+  author={Berger, Abi},
+  journal={BMJ: British Medical Journal},
+  volume={324},
+  number={7328},
+  pages={35},
+  year={2002},
+  publisher={BMJ Publishing Group}
 }
 
-@article{heunis2021effects,
-	title = {The effects of multi-echo fMRI combination and rapid T2*-mapping on offline and real-time BOLD sensitivity},
-	journal = {NeuroImage},
-	volume = {238},
-	pages = {118244},
-	year = {2021},
-	issn = {1053-8119},
-	doi = {https://doi.org/10.1016/j.neuroimage.2021.118244},
-	url = {https://www.sciencedirect.com/science/article/pii/S1053811921005218},
-	author = {Stephan Heunis and Marcel Breeuwer and César Caballero-Gaudes and Lydia Hellrung and Willem Huijbers and Jacobus FA Jansen and Rolf Lamerichs and Svitlana Zinger and Albert P Aldenkamp},
-	keywords = {Real-time, Multi-echo, Functional magnetic resonance imaging, Neurofeedback, Adaptive paradigms, Methods development, Finger tapping, Motor, Emotion processing, Amygdala, Task, Resting state},
-	abstract = {A variety of strategies are used to combine multi-echo functional magnetic resonance imaging (fMRI) data, yet recent literature lacks a systematic comparison of the available options. Here we compare six different approaches derived from multi-echo data and evaluate their influences on BOLD sensitivity for offline and in particular real-time use cases: a single-echo time series (based on Echo 2), the real-time T2*-mapped time series (T2*FIT) and four combined time series (T2*-weighted, tSNR-weighted, TE-weighted, and a new combination scheme termed T2*FIT-weighted). We compare the influences of these six multi-echo derived time series on BOLD sensitivity using a healthy participant dataset (N = 28) with four task-based fMRI runs and two resting state runs. We show that the T2*FIT-weighted combination yields the largest increase in temporal signal-to-noise ratio across task and resting state runs. We demonstrate additionally for all tasks that the T2*FIT time series consistently yields the largest offline effect size measures and real-time region-of-interest based functional contrasts and temporal contrast-to-noise ratios. These improvements show the promising utility of multi-echo fMRI for studies employing real-time paradigms, while further work is advised to mitigate the decreased tSNR of the T2*FIT time series. We recommend the use and continued exploration of T2*FIT for offline task-based and real-time region-based fMRI analysis. Supporting information includes: a data repository (https://dataverse.nl/dataverse/rt-me-fmri), an interactive web-based application to explore the data (https://rt-me-fmri.herokuapp.com/), and further materials and code for reproducibility (https://github.com/jsheunis/rt-me-fMRI).}
+@article{buur2008extraction-629, 
+  year     = {2008}, 
+  title    = {Extraction of Task-Related Activation from Multi-Echo BOLD fMRI}, 
+  author   = {Buur, Pieter F. and Norris, David G. and Hesse, Christian W.}, 
+  journal  = {IEEE Journal of Selected Topics in Signal Processing}, 
+  issn     = {1932-4553}, 
+  doi      = {10.1109/jstsp.2008.2007817}, 
+  abstract = {The development of parallel imaging technology has made possible the acquisition of multiple ${\rm T}_{2}^{\ast}$-weighted MRI images after a single excitation. This has opened new possibilities for functional MRI using the blood oxygenation level dependent (BOLD) contrast mechanism, which has conventionally acquired a single image at a fixed echo time TE. Regarding the multi-echo functional magnetic resonance imaging (fMRI) time-series at each voxel as a simultaneously sampled multichannel signal facilitates the application of established multichannel source extraction methods, which could provide improved estimates of the underlying signal component reflecting task-related BOLD. This work considers ten methods reflecting three different source extraction approaches in which either the TE dependence of the BOLD contrast is exploited, the correlation with an expected response (or design matrix) is maximized, or a maximally task-related component is selected from a statistical signal decomposition. The performance of these methods in extracting task-related BOLD activation minimally contaminated by head motion artifacts is examined in the context of an fMRI experiment in which the multi-echo data are systematically corrupted with varying degrees of artificially induced head motion. The best results were obtained with least-squares methods applied to log-transformed data, namely, adaptive beamforming using only the echo-times, and Wiener filtering using the design matrix.}, 
+  pages    = {954--964}, 
+  number   = {6}, 
+  volume   = {2}
 }
 
-@article{DuPre2021,
-  doi = {10.21105/joss.03669},
-  url = {https://doi.org/10.21105/joss.03669},
-  year = {2021},
-  publisher = {The Open Journal},
-  volume = {6},
-  number = {66},
-  pages = {3669},
-  author = {Elizabeth DuPre and Taylor Salo and Zaki Ahmed and Peter A. Bandettini and Katherine L. Bottenhorn and César Caballero-Gaudes and Logan T. Dowdle and Javier Gonzalez-Castillo and Stephan Heunis and Prantik Kundu and Angela R. Laird and Ross Markello and Christopher J. Markiewicz and Stefano Moia and Isla Staden and Joshua B. Teves and Eneko Uruñuela and Maryam Vaziri-Pashkam and Kirstie Whitaker and Daniel A. Handwerker},
-  title = {TE-dependent analysis of multi-echo fMRI with *tedana*},
-  journal = {Journal of Open Source Software}
-}
-
-@article{MOIA2021117914,
-	title = {ICA-based denoising strategies in breath-hold induced cerebrovascular reactivity mapping with multi echo BOLD fMRI},
-	journal = {NeuroImage},
-	volume = {233},
-	pages = {117914},
-	year = {2021},
-	issn = {1053-8119},
-	doi = {https://doi.org/10.1016/j.neuroimage.2021.117914},
-	url = {https://www.sciencedirect.com/science/article/pii/S1053811921001919},
-	author = {Stefano Moia and Maite Termenon and Eneko Uruñuela and Gang Chen and Rachael C. Stickland and Molly G. Bright and César Caballero-Gaudes},
-	keywords = {Cerebrovascular reactivity, Breath-hold, Multi-echo fMRI, Independent component analysis, Denoising, Precision functional mapping},
-	abstract = {Performing a BOLD functional MRI (fMRI) acquisition during breath-hold (BH) tasks is a non-invasive, robust method to estimate cerebrovascular reactivity (CVR). However, movement and breathing-related artefacts caused by the BH can substantially hinder CVR estimates due to their high temporal collinearity with the effect of interest, and attention has to be paid when choosing which analysis model should be applied to the data. In this study, we evaluate the performance of multiple analysis strategies based on lagged general linear models applied on multi-echo BOLD fMRI data, acquired in ten subjects performing a BH task during ten sessions, to obtain subject-specific CVR and haemodynamic lag estimates. The evaluated approaches range from conventional regression models, i.e. including drifts and motion timecourses as nuisance regressors, applied on single-echo or optimally-combined data, to more complex models including regressors obtained from multi-echo independent component analysis with different grades of orthogonalization in order to preserve the effect of interest, i.e. the CVR. We compare these models in terms of their ability to make signal intensity changes independent from motion, as well as the reliability as measured by voxelwise intraclass correlation coefficients of both CVR and lag maps over time. Our results reveal that a conservative independent component analysis model applied on the optimally-combined multi-echo fMRI signal offers the largest reduction of motion-related effects in the signal, while yielding reliable CVR amplitude and lag estimates, although a conventional regression model applied on the optimally-combined data results in similar estimates. This work demonstrates the usefulness of multi-echo based fMRI acquisitions and independent component analysis denoising for precision mapping of CVR in single subjects based on BH paradigms, fostering its potential as a clinically-viable neuroimaging tool for individual patients. It also proves that the way in which data-driven regressors should be incorporated in the analysis model is not straight-forward due to their complex interaction with the BH-induced BOLD response.}
+@article{bright2013removing,
+  title={Removing motion and physiological artifacts from intrinsic BOLD fluctuations using short echo data},
+  author={Bright, Molly G and Murphy, Kevin},
+  journal={Neuroimage},
+  volume={64},
+  pages={526--537},
+  year={2013},
+  publisher={Elsevier}
 }
 
 @article{cohen2019improving,
@@ -61,88 +43,15 @@
 	publisher={Nature Publishing Group}
 }
 
-@article{POSSE2012665,
-	title = {Multi-echo acquisition},
-	journal = {NeuroImage},
-	volume = {62},
-	number = {2},
-	pages = {665-671},
-	year = {2012},
-	note = {20 YEARS OF fMRI},
-	issn = {1053-8119},
-	doi = {https://doi.org/10.1016/j.neuroimage.2011.10.057},
-	url = {https://www.sciencedirect.com/science/article/pii/S1053811911012213},
-	author = {Stefan Posse},
-	keywords = {Functional MRI, Multi-echo acquisition, BOLD contrast, Quantification, Z-shimming},
-	abstract = {The rapid development of fMRI was paralleled early on by the adaptation of MR spectroscopic imaging (MRSI) methods to quantify water relaxation changes during brain activation. This review describes the evolution of multi-echo acquisition from high-speed MRSI to multi-echo EPI and beyond. It highlights milestones in the development of multi-echo acquisition methods, such as the discovery of considerable gains in fMRI sensitivity when combining echo images, advances in quantification of the BOLD effect using analytical biophysical modeling and interleaved multi-region shimming. The review conveys the insight gained from combining fMRI and MRSI methods and concludes with recent trends in ultra-fast fMRI, which will significantly increase temporal resolution of multi-echo acquisition.}
-}
-
-@article{KUNDU201759,
-	title = {Multi-echo fMRI: A review of applications in fMRI denoising and analysis of BOLD signals},
-	journal = {NeuroImage},
-	volume = {154},
-	pages = {59-80},
-	year = {2017},
-	note = {Cleaning up the fMRI time series: Mitigating noise with advanced acquisition and correction strategies},
-	issn = {1053-8119},
-	doi = {https://doi.org/10.1016/j.neuroimage.2017.03.033},
-	url = {https://www.sciencedirect.com/science/article/pii/S1053811917302410},
-	author = {Prantik Kundu and Valerie Voon and Priti Balchandani and Michael V. Lombardo and Benedikt A. Poser and Peter A. Bandettini},
-	abstract = {In recent years the field of fMRI research has enjoyed expanded technical abilities related to resolution, as well as use across many fields of brain research. At the same time, the field has also dealt with uncertainty related to many known and unknown effects of artifact in fMRI data. In this review we discuss an emerging fMRI technology, called multi-echo (ME)-fMRI, which focuses on improving the fidelity and interpretability of fMRI. Where the essential problem of standard single-echo fMRI is the indeterminacy of sources of signals, whether BOLD or artifact, this is not the case for ME-fMRI. By acquiring multiple echo images per slice, the ME approach allows T2* decay to be modeled at every voxel at every time point. Since BOLD signals arise by changes in T2* over time, an fMRI experiment sampling the T2* signal decay can be analyzed to distinguish BOLD from artifact signal constituents. While the ME approach has a long history of use in theoretical and validation studies, modern MRI systems enable whole-brain multi-echo fMRI at high resolution. This review covers recent multi-echo fMRI acquisition methods, and the analysis steps for this data to make fMRI at once more principled, straightforward, and powerful. After a brief overview of history and theory, T2* modeling and applications will be discussed. These applications include T2* mapping and combining echoes from ME data to increase BOLD contrast and mitigate dropout artifacts. Next, the modeling of fMRI signal changes to detect signal origins in BOLD-related T2* versus artifact-related S0 changes will be reviewed. A focus is on the use of ME-fMRI data to extract and classify components from spatial ICA, called multi-echo ICA (ME-ICA). After describing how ME-fMRI and ME-ICA lead to a general model for analysis of fMRI signals, applications in animal and human imaging will be discussed. Applications include removing motion artifacts in resting state data at subject and group level. New imaging methods such as multi-band multi-echo fMRI and imaging at 7T are demonstrated throughout the review, and a practical analysis pipeline is described. The review culminates with evidence from recent studies of major boosts in statistical power from using multi-echo fMRI for detecting activation and connectivity in healthy individuals and patients with neuropsychiatric disease. In conclusion, the review shows evidence that the multi-echo approach expands the range of experiments that is practicable using fMRI. These findings suggest a compelling future role of the multi-echo approach in subject-level and clinical fMRI.}
-}
-
-@article{OLAFSSON201543,
-	title = {Enhanced identification of BOLD-like components with multi-echo simultaneous multi-slice (MESMS) fMRI and multi-echo ICA},
-	journal = {NeuroImage},
-	volume = {112},
-	pages = {43-51},
-	year = {2015},
-	issn = {1053-8119},
-	doi = {https://doi.org/10.1016/j.neuroimage.2015.02.052},
-	url = {https://www.sciencedirect.com/science/article/pii/S1053811915001536},
-	author = {Valur Olafsson and Prantik Kundu and Eric C. Wong and Peter A. Bandettini and Thomas T. Liu},
-	abstract = {The recent introduction of simultaneous multi-slice (SMS) acquisitions has enabled the acquisition of blood oxygen level dependent (BOLD) functional magnetic resonance imaging (fMRI) data with significantly higher temporal sampling rates. In a parallel development, the use of multi-echo fMRI acquisitions in conjunction with a multi-echo independent component analysis (ME-ICA) approach has been introduced as a means to automatically distinguish functionally-related BOLD signal components from signal artifacts, with significant gains in sensitivity, statistical power, and specificity. In this work, we examine the gains that can be achieved with a combined approach in which data obtained with a multi-echo simultaneous multi-slice (MESMS) acquisition are analyzed with ME-ICA. We find that ME-ICA identifies significantly more BOLD-like components in the MESMS data as compared to data acquired with a conventional multi-echo single-slice acquisition. We demonstrate that the improved performance of MESMS derives from both an increase in the number of temporal samples and the enhanced ability to filter out high-frequency artifacts.}
-}
-
-@ARTICLE{Kundu2013-po,
-  title   = "Integrated strategy for improving functional connectivity mapping
-             using multiecho {fMRI}",
-  author  = "Kundu, P and Brenowitz, N D and Voon, V and Worbe, Y and Vertes, P
-             E and Inati, S J and Saad, Z S and Bandettini, P A and Bullmore, E
-             T",
-  journal = "Proceedings of the National Academy of Sciences",
-  volume  =  110,
-  number  =  40,
-  pages   = "16187--16192",
-  year    =  2013
-}
-
-@ARTICLE{Shafto2014-lg,
-  title   = "The Cambridge Centre for Ageing and Neuroscience ({Cam-CAN}) study
-             protocol: a cross-sectional, lifespan, multidisciplinary
-             examination of healthy cognitive ageing",
-  author  = "Shafto, Meredith A and {Cam-CAN} and Tyler, Lorraine K and Dixon,
-             Marie and Taylor, Jason R and Rowe, James B and Cusack, Rhodri and
-             Calder, Andrew J and Marslen-Wilson, William D and Duncan, John
-             and Dalgleish, Tim and Henson, Richard N and Brayne, Carol and
-             Matthews, Fiona E",
-  journal = "BMC Neurology",
-  volume  =  14,
-  number  =  1,
-  year    =  2014
-}
-
-@article {Li2021.10.02.462875,
-	author = {Li, Jixing and Bhattasali, Shohini and Zhang, Shulin and Franzluebbers, Berta and Luh, Wen-Ming and Spreng, R. Nathan and Brennan, Jonathan R. and Yang, Yiming and Pallier, Christophe and Hale, John},
-	title = {Le Petit Prince: A multilingual fMRI corpus using ecological stimuli},
-	elocation-id = {2021.10.02.462875},
-	year = {2021},
-	doi = {10.1101/2021.10.02.462875},
-	publisher = {Cold Spring Harbor Laboratory},
-	abstract = {Neuroimaging using more ecologically valid stimuli such as audiobooks has advanced our understanding of natural language comprehension in the brain. However, prior naturalistic stimuli have typically been restricted to a single language, which limited generalizability beyond small typological domains. Here we present the Le Petit Prince fMRI Corpus (LPPC{\textendash}fMRI), a multilingual resource for research in the cognitive neuroscience of speech and language during naturalistic listening (Open-Neuro: ds003643). 49 English speakers, 35 Chinese speakers and 28 French speakers listened to the same audiobook The Little Prince in their native language while multi-echo functional magnetic resonance imaging was acquired. We also provide time-aligned speech annotation and word-by-word predictors obtained using natural language processing tools. The resulting timeseries data are shown to be of high quality with good temporal signal-to-noise ratio and high inter-subject correlation. Data-driven functional analyses provide further evidence of data quality. This annotated, multilingual fMRI dataset facilitates future re-analysis that addresses cross-linguistic commonalities and differences in the neural substrate of language processing on multiple perceptual and linguistic levels.Competing Interest StatementThe authors have declared no competing interest.},
-	URL = {https://www.biorxiv.org/content/early/2021/10/04/2021.10.02.462875},
-	eprint = {https://www.biorxiv.org/content/early/2021/10/04/2021.10.02.462875.full.pdf},
-	journal = {bioRxiv}
+@article{cohen2012t2,
+  title={T2* mapping and B0 orientation-dependence at 7 T reveal cyto-and myeloarchitecture organization of the human cortex},
+  author={Cohen-Adad, Julien and Polimeni, Jonathan R and Helmer, Karl G and Benner, Thomas and McNab, Jennifer A and Wald, Lawrence L and Rosen, Bruce R and Mainero, Caterina},
+  journal={Neuroimage},
+  volume={60},
+  number={2},
+  pages={1006--1014},
+  year={2012},
+  publisher={Elsevier}
 }
 
 @article{DALENBERG2018734,
@@ -158,58 +67,6 @@
 	abstract = {Although it is often assumed that valence processing in the prefrontal cortex (PFC) is similar for stimuli originating from different sensory modalities, evidence supporting this view is lacking. To address this, we recruited 20 male participants and used a delayed-response fMRI design to test whether perceived pleasantness of flavors and images is similarly processed in the PFC. As predicted, significant correlations were observed between image and flavor pleasantness ratings, and PFC response to these stimuli; however, these responses were spatially different, with flavor pleasantness reflected in more ventrally located PFC regions than image pleasantness. These results indicate that, contrary to the general assumption of a singular circuit representing pleasantness, distinct PFC circuits are recruited depending upon stimulus modality. We argue that the ventral-dorsal distinction may be attributed to a difference in proximal versus distal stimulus representations.}
 }
 
-@article{dupre2016multi,
-  title={Multi-echo fMRI replication sample of autobiographical memory, prospection and theory of mind reasoning tasks},
-  author={DuPre, Elizabeth and Luh, Wen-Ming and Spreng, R Nathan},
-  journal={Scientific data},
-  volume={3},
-  number={1},
-  pages={1--9},
-  year={2016},
-  publisher={Nature Publishing Group}
-}
-
-@article{spreng2022neurocognitive,
-  title={Neurocognitive aging data release with behavioral, structural and multi-echo functional MRI measures},
-  author={Spreng, RN and Setton, R and Alter, U and Cassidy, BN and Darboh, B and DuPre, E and Kantarovich, K and Lockrow, AW and Mwilambwe-Tshilobo, L and Luh, WM and others},
-  journal={Scientific Data},
-  year={2022},
-  url={https://doi.org/10.1038/s41597-022-01231-7},
-  doi={10.1038/s41597-022-01231-7},
-  abstract={Central to understanding human behavior is a comprehensive mapping of brain-behavior relations within the context of lifespan development. Reproducible discoveries depend upon well-powered samples of reliable data. We provide to the scientific community two, 10-minute, multi-echo functional MRI (ME-fMRI) runs, and structural MRI (T1-MPRAGE), from 181 healthy younger (ages 18–34 y) and 120 older adults (ages 60–89 y). T2-FLAIR MRIs and behavioral assessments are available in a majority subset of over 250 participants. Behavioral assessments include fluid and crystallized cognition, self-reported measures of personality, and socioemotional functioning. Initial quality control and validation of these data is provided. This dataset will be of value to scientists interested in BOLD signal specifically isolated from ME-fMRI, individual differences in brain-behavioral associations, and cross-sectional aging effects in healthy adults. Demographic and behavioral data are available within the Open Science Framework project “Goal-Directed Cognition in Older and Younger Adults” (http://osf.io/yhzxe/), which will be augmented over time; neuroimaging data are available on OpenNeuro (https://openneuro.org/datasets/ds003592)}
-}
-
-@article{cohen2012t2,
-  title={T2* mapping and B0 orientation-dependence at 7 T reveal cyto-and myeloarchitecture organization of the human cortex},
-  author={Cohen-Adad, Julien and Polimeni, Jonathan R and Helmer, Karl G and Benner, Thomas and McNab, Jennifer A and Wald, Lawrence L and Rosen, Bruce R and Mainero, Caterina},
-  journal={Neuroimage},
-  volume={60},
-  number={2},
-  pages={1006--1014},
-  year={2012},
-  publisher={Elsevier}
-}
-
-@article{ruuth2019comparison,
-  title={Comparison of reconstruction and acquisition choices for quantitative T2* maps and synthetic contrasts},
-  author={Ruuth, Riikka and Kuusela, Linda and M{\"a}kel{\"a}, Teemu and Melkas, Susanna and Korvenoja, Antti},
-  journal={European journal of radiology open},
-  volume={6},
-  pages={42--48},
-  year={2019},
-  publisher={Elsevier}
-}
-
-@article{bright2013removing,
-  title={Removing motion and physiological artifacts from intrinsic BOLD fluctuations using short echo data},
-  author={Bright, Molly G and Murphy, Kevin},
-  journal={Neuroimage},
-  volume={64},
-  pages={526--537},
-  year={2013},
-  publisher={Elsevier}
-}
-
 @article{dipasquale2017comparing,
   title={Comparing resting state fMRI de-noising approaches using multi-and single-echo acquisitions},
   author={Dipasquale, Ottavia and Sethi, Arjun and Lagan{\`a}, Maria Marcella and Baglio, Francesca and Baselli, Giuseppe and Kundu, Prantik and Harrison, Neil A and Cercignani, Mara},
@@ -219,39 +76,6 @@
   pages={e0173289},
   year={2017},
   publisher={Public Library of Science San Francisco, CA USA}
-}
-
-@article{hovet2018mri,
-  title={MRI-powered biomedical devices},
-  author={Hovet, Sierra and Ren, Hongliang and Xu, Sheng and Wood, Bradford and Tokuda, Junichi and Tse, Zion Tsz Ho},
-  journal={Minimally Invasive Therapy \& Allied Technologies},
-  volume={27},
-  number={4},
-  pages={191--202},
-  year={2018},
-  publisher={Taylor \& Francis}
-}
-
-@article{berger2002does,
-  title={How does it work?: Magnetic resonance imaging},
-  author={Berger, Abi},
-  journal={BMJ: British Medical Journal},
-  volume={324},
-  number={7328},
-  pages={35},
-  year={2002},
-  publisher={BMJ Publishing Group}
-}
-
-@article{vizioli2021lowering,
-  title={Lowering the thermal noise barrier in functional brain mapping with magnetic resonance imaging},
-  author={Vizioli, Luca and Moeller, Steen and Dowdle, Logan and Ak{\c{c}}akaya, Mehmet and De Martino, Federico and Yacoub, Essa and U{\u{g}}urbil, Kamil},
-  journal={Nature communications},
-  volume={12},
-  number={1},
-  pages={5181},
-  year={2021},
-  publisher={Nature Publishing Group UK London}
 }
 
 @article{dowdle2021nordic,
@@ -273,10 +97,309 @@
   publisher={Elsevier}
 }
 
+@article{dupre2016multi,
+  title={Multi-echo fMRI replication sample of autobiographical memory, prospection and theory of mind reasoning tasks},
+  author={DuPre, Elizabeth and Luh, Wen-Ming and Spreng, R Nathan},
+  journal={Scientific data},
+  volume={3},
+  number={1},
+  pages={1--9},
+  year={2016},
+  publisher={Nature Publishing Group}
+}
+
+@article{DuPre2021,
+  doi = {10.21105/joss.03669},
+  url = {https://doi.org/10.21105/joss.03669},
+  year = {2021},
+  publisher = {The Open Journal},
+  volume = {6},
+  number = {66},
+  pages = {3669},
+  author = {Elizabeth DuPre and Taylor Salo and Zaki Ahmed and Peter A. Bandettini and Katherine L. Bottenhorn and César Caballero-Gaudes and Logan T. Dowdle and Javier Gonzalez-Castillo and Stephan Heunis and Prantik Kundu and Angela R. Laird and Ross Markello and Christopher J. Markiewicz and Stefano Moia and Isla Staden and Joshua B. Teves and Eneko Uruñuela and Maryam Vaziri-Pashkam and Kirstie Whitaker and Daniel A. Handwerker},
+  title = {TE-dependent analysis of multi-echo fMRI with *tedana*},
+  journal = {Journal of Open Source Software}
+}
+
+@article{hennig1994detection-075, 
+  year     = {1994}, 
+  title    = {Detection of brain activation using oxygenation sensitive functional spectroscopy}, 
+  author   = {Hennig, J. and Emst, Th. and Speck, O. and Deuschl, G. and Feifel, E.}, 
+  journal  = {Magnetic Resonance in Medicine}, 
+  issn     = {0740-3194}, 
+  doi      = {10.1002/mrm.1910310115}, 
+  pmid     = {8121276}, 
+  abstract = {A nonwater‐suppressed localized spectroscopy experiment using the PRESS‐sequence has been used to study the signal changes of the water resonance during cortical activation. Significant effects with an effect‐to‐noise ratio up to 50:1 for a single shot experiment have been observed upon photic stimulation. The exceedingly high signal‐to‐noise ratio of the experiment was used to demonstrate signal changes as low as 0.1% after electrical stimulation of the median nerve.}, 
+  pages    = {85--90}, 
+  number   = {1}, 
+  volume   = {31}
+}
+
+@article{heunis2021effects,
+	title = {The effects of multi-echo fMRI combination and rapid T2*-mapping on offline and real-time BOLD sensitivity},
+	journal = {NeuroImage},
+	volume = {238},
+	pages = {118244},
+	year = {2021},
+	issn = {1053-8119},
+	doi = {https://doi.org/10.1016/j.neuroimage.2021.118244},
+	url = {https://www.sciencedirect.com/science/article/pii/S1053811921005218},
+	author = {Stephan Heunis and Marcel Breeuwer and César Caballero-Gaudes and Lydia Hellrung and Willem Huijbers and Jacobus FA Jansen and Rolf Lamerichs and Svitlana Zinger and Albert P Aldenkamp},
+	keywords = {Real-time, Multi-echo, Functional magnetic resonance imaging, Neurofeedback, Adaptive paradigms, Methods development, Finger tapping, Motor, Emotion processing, Amygdala, Task, Resting state},
+	abstract = {A variety of strategies are used to combine multi-echo functional magnetic resonance imaging (fMRI) data, yet recent literature lacks a systematic comparison of the available options. Here we compare six different approaches derived from multi-echo data and evaluate their influences on BOLD sensitivity for offline and in particular real-time use cases: a single-echo time series (based on Echo 2), the real-time T2*-mapped time series (T2*FIT) and four combined time series (T2*-weighted, tSNR-weighted, TE-weighted, and a new combination scheme termed T2*FIT-weighted). We compare the influences of these six multi-echo derived time series on BOLD sensitivity using a healthy participant dataset (N = 28) with four task-based fMRI runs and two resting state runs. We show that the T2*FIT-weighted combination yields the largest increase in temporal signal-to-noise ratio across task and resting state runs. We demonstrate additionally for all tasks that the T2*FIT time series consistently yields the largest offline effect size measures and real-time region-of-interest based functional contrasts and temporal contrast-to-noise ratios. These improvements show the promising utility of multi-echo fMRI for studies employing real-time paradigms, while further work is advised to mitigate the decreased tSNR of the T2*FIT time series. We recommend the use and continued exploration of T2*FIT for offline task-based and real-time region-based fMRI analysis. Supporting information includes: a data repository (https://dataverse.nl/dataverse/rt-me-fmri), an interactive web-based application to explore the data (https://rt-me-fmri.herokuapp.com/), and further materials and code for reproducibility (https://github.com/jsheunis/rt-me-fMRI).}
+}
+
+@article{hovet2018mri,
+  title={MRI-powered biomedical devices},
+  author={Hovet, Sierra and Ren, Hongliang and Xu, Sheng and Wood, Bradford and Tokuda, Junichi and Tse, Zion Tsz Ho},
+  journal={Minimally Invasive Therapy \& Allied Technologies},
+  volume={27},
+  number={4},
+  pages={191--202},
+  year={2018},
+  publisher={Taylor \& Francis}
+}
+
+@article{kundu2012differentiating-263, 
+  year     = {2012}, 
+  keywords = {*Artifacts, Algorithms, Brain/*physiology, Echo-Planar Imaging/*methods, Female, Functional Neuroimaging/*methods, Humans, Image Enhancement/*methods, Image Interpretation, Computer-Assisted/*methods, Pattern Recognition, Automated/*methods, Reproducibility of Results, Sensitivity and Specificity, Young Adult}, 
+  title    = {Differentiating BOLD and non-BOLD signals in fMRI time series using multi-echo EPI}, 
+  author   = {Kundu, P. and Inati, S. J. and Evans, J. W. and Luh, W. M. and Bandettini, P. A.}, 
+  journal  = {Neuroimage}, 
+  issn     = {1095-9572}, 
+  doi      = {10.1016/j.neuroimage.2011.12.028}, 
+  pmid     = {22209809}, 
+  pmcid    = {PMC3350785}, 
+  url      = {https://www.ncbi.nlm.nih.gov/pubmed/22209809}, 
+  pages    = {1759--70}, 
+  number   = {3}, 
+  volume   = {60}, 
+  language = {English}
+}
+
+
+@ARTICLE{Kundu2013-po,
+  title   = "Integrated strategy for improving functional connectivity mapping
+             using multiecho {fMRI}",
+  author  = "Kundu, P and Brenowitz, N D and Voon, V and Worbe, Y and Vertes, P
+             E and Inati, S J and Saad, Z S and Bandettini, P A and Bullmore, E
+             T",
+  journal = "Proceedings of the National Academy of Sciences",
+  volume  =  110,
+  number  =  40,
+  pages   = "16187--16192",
+  year    =  2013
+}
+
+@article{KUNDU201759,
+	title = {Multi-echo fMRI: A review of applications in fMRI denoising and analysis of BOLD signals},
+	journal = {NeuroImage},
+	volume = {154},
+	pages = {59-80},
+	year = {2017},
+	note = {Cleaning up the fMRI time series: Mitigating noise with advanced acquisition and correction strategies},
+	issn = {1053-8119},
+	doi = {https://doi.org/10.1016/j.neuroimage.2017.03.033},
+	url = {https://www.sciencedirect.com/science/article/pii/S1053811917302410},
+	author = {Prantik Kundu and Valerie Voon and Priti Balchandani and Michael V. Lombardo and Benedikt A. Poser and Peter A. Bandettini},
+	abstract = {In recent years the field of fMRI research has enjoyed expanded technical abilities related to resolution, as well as use across many fields of brain research. At the same time, the field has also dealt with uncertainty related to many known and unknown effects of artifact in fMRI data. In this review we discuss an emerging fMRI technology, called multi-echo (ME)-fMRI, which focuses on improving the fidelity and interpretability of fMRI. Where the essential problem of standard single-echo fMRI is the indeterminacy of sources of signals, whether BOLD or artifact, this is not the case for ME-fMRI. By acquiring multiple echo images per slice, the ME approach allows T2* decay to be modeled at every voxel at every time point. Since BOLD signals arise by changes in T2* over time, an fMRI experiment sampling the T2* signal decay can be analyzed to distinguish BOLD from artifact signal constituents. While the ME approach has a long history of use in theoretical and validation studies, modern MRI systems enable whole-brain multi-echo fMRI at high resolution. This review covers recent multi-echo fMRI acquisition methods, and the analysis steps for this data to make fMRI at once more principled, straightforward, and powerful. After a brief overview of history and theory, T2* modeling and applications will be discussed. These applications include T2* mapping and combining echoes from ME data to increase BOLD contrast and mitigate dropout artifacts. Next, the modeling of fMRI signal changes to detect signal origins in BOLD-related T2* versus artifact-related S0 changes will be reviewed. A focus is on the use of ME-fMRI data to extract and classify components from spatial ICA, called multi-echo ICA (ME-ICA). After describing how ME-fMRI and ME-ICA lead to a general model for analysis of fMRI signals, applications in animal and human imaging will be discussed. Applications include removing motion artifacts in resting state data at subject and group level. New imaging methods such as multi-band multi-echo fMRI and imaging at 7T are demonstrated throughout the review, and a practical analysis pipeline is described. The review culminates with evidence from recent studies of major boosts in statistical power from using multi-echo fMRI for detecting activation and connectivity in healthy individuals and patients with neuropsychiatric disease. In conclusion, the review shows evidence that the multi-echo approach expands the range of experiments that is practicable using fMRI. These findings suggest a compelling future role of the multi-echo approach in subject-level and clinical fMRI.}
+}
+
+@article {Li2021.10.02.462875,
+	author = {Li, Jixing and Bhattasali, Shohini and Zhang, Shulin and Franzluebbers, Berta and Luh, Wen-Ming and Spreng, R. Nathan and Brennan, Jonathan R. and Yang, Yiming and Pallier, Christophe and Hale, John},
+	title = {Le Petit Prince: A multilingual fMRI corpus using ecological stimuli},
+	elocation-id = {2021.10.02.462875},
+	year = {2021},
+	doi = {10.1101/2021.10.02.462875},
+	publisher = {Cold Spring Harbor Laboratory},
+	abstract = {Neuroimaging using more ecologically valid stimuli such as audiobooks has advanced our understanding of natural language comprehension in the brain. However, prior naturalistic stimuli have typically been restricted to a single language, which limited generalizability beyond small typological domains. Here we present the Le Petit Prince fMRI Corpus (LPPC{\textendash}fMRI), a multilingual resource for research in the cognitive neuroscience of speech and language during naturalistic listening (Open-Neuro: ds003643). 49 English speakers, 35 Chinese speakers and 28 French speakers listened to the same audiobook The Little Prince in their native language while multi-echo functional magnetic resonance imaging was acquired. We also provide time-aligned speech annotation and word-by-word predictors obtained using natural language processing tools. The resulting timeseries data are shown to be of high quality with good temporal signal-to-noise ratio and high inter-subject correlation. Data-driven functional analyses provide further evidence of data quality. This annotated, multilingual fMRI dataset facilitates future re-analysis that addresses cross-linguistic commonalities and differences in the neural substrate of language processing on multiple perceptual and linguistic levels.Competing Interest StatementThe authors have declared no competing interest.},
+	URL = {https://www.biorxiv.org/content/early/2021/10/04/2021.10.02.462875},
+	eprint = {https://www.biorxiv.org/content/early/2021/10/04/2021.10.02.462875.full.pdf},
+	journal = {bioRxiv}
+}
+
+@article{menon19934-e70, 
+  year     = {1993}, 
+  title    = {4 Tesla gradient recalled echo characteristics of photic stimulation‐induced signal changes in the human primary visual cortex}, 
+  author   = {Menon, Ravi S. and Ogawa, Seiji and Tank, David W. and Uǧurbil, Kǎmil}, 
+  journal  = {Magnetic Resonance in Medicine}, 
+  issn     = {0740-3194}, 
+  doi      = {10.1002/mrm.1910300317}, 
+  pmid     = {8412612}, 
+  abstract = {Multi‐echo measurements of photic stimulation‐induced signal changes in human visual cortex were made at 4 Tesla in order to quantify the nature of the signal change and its vascular origin, and to determine the optimum echo time for detection of the changes. Utilizing high resolution images, two distinct regions (ascribed to be microvasculature and visible venous vessels) were identified as giving rise to the signal increase. The fractional signal changes in gray matter areas depended linearly on echo time (TE) in the range of 10 to 60 ms and extrapolated to virtually zero for TE = 0, indicating that in‐flow effects secondary to stimulation‐induced blood flow increases were negligible in our functional imaging studies; instead, signal change due to photic stimulation originated from the increase in the apparent transverse relaxation rate, 1/T2*. This decrease in (1/T2*, brought about by the alterations in hemodynamic parameters, was 1.3 ± 0.4 s−1 for gray matter and 3.0 ± 0.7 s−1 (averaged over 10 individuals) for venous vessels visible in the images. The optimum choice of echo time was found to be TE ≥ T2*.}, 
+  pages    = {380--386}, 
+  number   = {3}, 
+  volume   = {30}
+}
+
+@article{MOIA2021117914,
+	title = {ICA-based denoising strategies in breath-hold induced cerebrovascular reactivity mapping with multi echo BOLD fMRI},
+	journal = {NeuroImage},
+	volume = {233},
+	pages = {117914},
+	year = {2021},
+	issn = {1053-8119},
+	doi = {https://doi.org/10.1016/j.neuroimage.2021.117914},
+	url = {https://www.sciencedirect.com/science/article/pii/S1053811921001919},
+	author = {Stefano Moia and Maite Termenon and Eneko Uruñuela and Gang Chen and Rachael C. Stickland and Molly G. Bright and César Caballero-Gaudes},
+	keywords = {Cerebrovascular reactivity, Breath-hold, Multi-echo fMRI, Independent component analysis, Denoising, Precision functional mapping},
+	abstract = {Performing a BOLD functional MRI (fMRI) acquisition during breath-hold (BH) tasks is a non-invasive, robust method to estimate cerebrovascular reactivity (CVR). However, movement and breathing-related artefacts caused by the BH can substantially hinder CVR estimates due to their high temporal collinearity with the effect of interest, and attention has to be paid when choosing which analysis model should be applied to the data. In this study, we evaluate the performance of multiple analysis strategies based on lagged general linear models applied on multi-echo BOLD fMRI data, acquired in ten subjects performing a BH task during ten sessions, to obtain subject-specific CVR and haemodynamic lag estimates. The evaluated approaches range from conventional regression models, i.e. including drifts and motion timecourses as nuisance regressors, applied on single-echo or optimally-combined data, to more complex models including regressors obtained from multi-echo independent component analysis with different grades of orthogonalization in order to preserve the effect of interest, i.e. the CVR. We compare these models in terms of their ability to make signal intensity changes independent from motion, as well as the reliability as measured by voxelwise intraclass correlation coefficients of both CVR and lag maps over time. Our results reveal that a conservative independent component analysis model applied on the optimally-combined multi-echo fMRI signal offers the largest reduction of motion-related effects in the signal, while yielding reliable CVR amplitude and lag estimates, although a conventional regression model applied on the optimally-combined data results in similar estimates. This work demonstrates the usefulness of multi-echo based fMRI acquisitions and independent component analysis denoising for precision mapping of CVR in single subjects based on BH paradigms, fostering its potential as a clinically-viable neuroimaging tool for individual patients. It also proves that the way in which data-driven regressors should be incorporated in the analysis model is not straight-forward due to their complex interaction with the BH-induced BOLD response.}
+}
+
+@article{OLAFSSON201543,
+	title = {Enhanced identification of BOLD-like components with multi-echo simultaneous multi-slice (MESMS) fMRI and multi-echo ICA},
+	journal = {NeuroImage},
+	volume = {112},
+	pages = {43-51},
+	year = {2015},
+	issn = {1053-8119},
+	doi = {https://doi.org/10.1016/j.neuroimage.2015.02.052},
+	url = {https://www.sciencedirect.com/science/article/pii/S1053811915001536},
+	author = {Valur Olafsson and Prantik Kundu and Eric C. Wong and Peter A. Bandettini and Thomas T. Liu},
+	abstract = {The recent introduction of simultaneous multi-slice (SMS) acquisitions has enabled the acquisition of blood oxygen level dependent (BOLD) functional magnetic resonance imaging (fMRI) data with significantly higher temporal sampling rates. In a parallel development, the use of multi-echo fMRI acquisitions in conjunction with a multi-echo independent component analysis (ME-ICA) approach has been introduced as a means to automatically distinguish functionally-related BOLD signal components from signal artifacts, with significant gains in sensitivity, statistical power, and specificity. In this work, we examine the gains that can be achieved with a combined approach in which data obtained with a multi-echo simultaneous multi-slice (MESMS) acquisition are analyzed with ME-ICA. We find that ME-ICA identifies significantly more BOLD-like components in the MESMS data as compared to data acquired with a conventional multi-echo single-slice acquisition. We demonstrate that the improved performance of MESMS derives from both an increase in the number of temporal samples and the enhanced ability to filter out high-frequency artifacts.}
+}
+
+
+@article{poser2006bold-bda, 
+  year     = {2006}, 
+  keywords = {*Artifacts, Adult, Algorithms, Brain Mapping/*methods, Brain/anatomy & histology/*metabolism, Echo-Planar Imaging/*methods, Female, Humans, Image Enhancement/*methods, Image Interpretation, Computer-Assisted/*methods, Magnetic Resonance Imaging/methods, Male, Oxygen/*metabolism, Reproducibility of Results, Sensitivity and Specificity}, 
+  title    = {BOLD contrast sensitivity enhancement and artifact reduction with multiecho EPI: parallel-acquired inhomogeneity-desensitized fMRI}, 
+  author   = {Poser, B. A. and Versluis, M. J. and Hoogduin, J. M. and Norris, D. G.}, 
+  journal  = {Magn Reson Med}, 
+  issn     = {0740-3194}, 
+  doi      = {10.1002/mrm.20900}, 
+  pmid     = {16680688}, 
+  url      = {https://www.ncbi.nlm.nih.gov/pubmed/16680688}, 
+  abstract = {Functional MRI (fMRI) generally employs gradient-echo echo-planar imaging (GE-EPI) to measure blood oxygen level-dependent (BOLD) signal changes that result from changes in tissue relaxation time T(*) (2) between activation and rest. Since T(*) (2) strongly varies across the brain and BOLD contrast is maximal only where the echo time (TE) equals the local T(*) (2), imaging at a single TE is a compromise in terms of overall sensitivity. Furthermore, the long echo train makes EPI very sensitive to main field inhomogeneities, causing strong image distortion. A method is presented that uses accelerated parallel imaging to reduce image artifacts and acquire images at multiple TEs following a single excitation, with no need to increase TR. Sensitivity gains from the broadened T(*) (2) coverage are optimized by pixelwise weighted echo summation based on local T(*) (2) or contrast-to-noise ratio (CNR) measurements. The method was evaluated using an approach that allows differential BOLD CNR to be calculated without stimulation, as well as with a Stroop experiment. Results obtained at 3 T showed that BOLD sensitivity improved by 11% or more in all brain regions, with larger gains in areas typically affected by strong susceptibility artifacts. The use of parallel imaging markedly reduces image distortion, and hence the method should find widespread application in functional brain imaging.}, 
+  pages    = {1227--35}, 
+  number   = {6}, 
+  volume   = {55}, 
+  language = {English}
+}
+
+@article{posse1999enhancement-176, 
+  year     = {1999}, 
+  keywords = {Adult, Brain/*physiology, Computer Simulation, Echo-Planar Imaging/*instrumentation, Humans, Image Enhancement/*instrumentation, Image Processing, Computer-Assisted/*instrumentation, Magnetic Resonance Imaging/*instrumentation, Male, Oxygen/*blood, Reference Values, Sensitivity and Specificity, Visual Perception/physiology}, 
+  title    = {Enhancement of BOLD-contrast sensitivity by single-shot multi-echo functional MR imaging}, 
+  author   = {Posse, S. and Wiese, S. and Gembris, D. and Mathiak, K. and Kessler, C. and Grosse-Ruyken, M. L. and Elghahwagi, B. and Richards, T. and Dager, S. R. and Kiselev, V. G.}, 
+  journal  = {Magn Reson Med}, 
+  issn     = {0740-3194}, 
+  doi      = {10.1002/(sici)1522-2594(199907)42:1<87::aid-mrm13>3.0.co;2-o}, 
+  pmid     = {10398954}, 
+  url      = {https://www.ncbi.nlm.nih.gov/pubmed/10398954}, 
+  pages    = {87--97}, 
+  number   = {1}, 
+  volume   = {42}, 
+  language = {eng}
+}
+
+@article{POSSE2012665,
+	title = {Multi-echo acquisition},
+	journal = {NeuroImage},
+	volume = {62},
+	number = {2},
+	pages = {665-671},
+	year = {2012},
+	note = {20 YEARS OF fMRI},
+	issn = {1053-8119},
+	doi = {https://doi.org/10.1016/j.neuroimage.2011.10.057},
+	url = {https://www.sciencedirect.com/science/article/pii/S1053811911012213},
+	author = {Stefan Posse},
+	keywords = {Functional MRI, Multi-echo acquisition, BOLD contrast, Quantification, Z-shimming},
+	abstract = {The rapid development of fMRI was paralleled early on by the adaptation of MR spectroscopic imaging (MRSI) methods to quantify water relaxation changes during brain activation. This review describes the evolution of multi-echo acquisition from high-speed MRSI to multi-echo EPI and beyond. It highlights milestones in the development of multi-echo acquisition methods, such as the discovery of considerable gains in fMRI sensitivity when combining echo images, advances in quantification of the BOLD effect using analytical biophysical modeling and interleaved multi-region shimming. The review conveys the insight gained from combining fMRI and MRSI methods and concludes with recent trends in ultra-fast fMRI, which will significantly increase temporal resolution of multi-echo acquisition.}
+}
+
+@article{power2018ridding,
+	title={Ridding fMRI data of motion-related influences: Removal of signals with distinct spatial and physical bases in multiecho data},
+	author={Power, Jonathan D and Plitt, Mark and Gotts, Stephen J and Kundu, Prantik and Voon, Valerie and Bandettini, Peter A and Martin, Alex},
+	journal={Proceedings of the National Academy of Sciences},
+	volume={115},
+	number={9},
+	pages={E2105--E2114},
+	year={2018},
+	publisher={National Acad Sciences}
+}
+
+@article{ruuth2019comparison,
+  title={Comparison of reconstruction and acquisition choices for quantitative T2* maps and synthetic contrasts},
+  author={Ruuth, Riikka and Kuusela, Linda and M{\"a}kel{\"a}, Teemu and Melkas, Susanna and Korvenoja, Antti},
+  journal={European journal of radiology open},
+  volume={6},
+  pages={42--48},
+  year={2019},
+  publisher={Elsevier}
+}
+
+@article{setsompop2012blipped-controlled-1a0, 
+  year     = {2012}, 
+  keywords = {*Artifacts, Algorithms, Brain/*anatomy & histology, Echo-Planar Imaging/*methods, Humans, Image Enhancement/*methods, Image Interpretation, Computer-Assisted/*methods, Imaging, Three-Dimensional/*methods, Pattern Recognition, Automated/*methods, Reproducibility of Results, Sensitivity and Specificity, Signal Processing, Computer-Assisted}, 
+  title    = {Blipped-controlled aliasing in parallel imaging for simultaneous multislice echo planar imaging with reduced g-factor penalty}, 
+  author   = {Setsompop, K. and Gagoski, B. A. and Polimeni, J. R. and Witzel, T. and Wedeen, V. J. and Wald, L. L.}, 
+  journal  = {Magn Reson Med}, 
+  issn     = {1522-2594}, 
+  doi      = {10.1002/mrm.23097}, 
+  pmid     = {21858868}, 
+  pmcid    = {PMC3323676}, 
+  url      = {https://www.ncbi.nlm.nih.gov/pubmed/21858868}, 
+  pages    = {1210--24}, 
+  number   = {5}, 
+  volume   = {67}, 
+  language = {English}, 
+}
+
+@ARTICLE{Shafto2014-lg,
+  title   = "The Cambridge Centre for Ageing and Neuroscience ({Cam-CAN}) study
+             protocol: a cross-sectional, lifespan, multidisciplinary
+             examination of healthy cognitive ageing",
+  author  = "Shafto, Meredith A and {Cam-CAN} and Tyler, Lorraine K and Dixon,
+             Marie and Taylor, Jason R and Rowe, James B and Cusack, Rhodri and
+             Calder, Andrew J and Marslen-Wilson, William D and Duncan, John
+             and Dalgleish, Tim and Henson, Richard N and Brayne, Carol and
+             Matthews, Fiona E",
+  journal = "BMC Neurology",
+  volume  =  14,
+  number  =  1,
+  year    =  2014
+}
+
+@article{speck1998functional-366, 
+  year     = {1998}, 
+  title    = {Functional Imaging by I0‐ and T2* ‐parameter mapping using multi‐image EPI}, 
+  author   = {Speck, Oliver and Hennig, Jürgen}, 
+  journal  = {Magnetic Resonance in Medicine}, 
+  issn     = {0740-3194}, 
+  doi      = {10.1002/mrm.1910400210}, 
+  pmid     = {9702706}, 
+  abstract = {A new functional imaging method has been developed and used to measure T2*‐ and initial intensity (I0)‐parameter maps of multiple slices during activation of the cortex with high temporal resolution. Multiple echo‐planar images (EPls) are read out after a single excitation of the spin system, leading to several images with increasing effective echo times. Changes induced by primary visual stimulation in T2* and I0 were measured in eight subjects. Although stimulation‐induced increases in I0 only occurred at short repetition times, T2* increased from 57.3 to 60.9 ms on average. The method combines the high stability of a single shot EPI experiment with the high information content of a multiecho acquisition. In addition, stimulation‐induced changes in inflow can be easily separated from true blood oxygenation level dependent (BOLD) signal changes.}, 
+  pages    = {243--248}, 
+  number   = {2}, 
+  volume   = {40}
+}
+@article{spreng2022neurocognitive,
+  title={Neurocognitive aging data release with behavioral, structural and multi-echo functional MRI measures},
+  author={Spreng, RN and Setton, R and Alter, U and Cassidy, BN and Darboh, B and DuPre, E and Kantarovich, K and Lockrow, AW and Mwilambwe-Tshilobo, L and Luh, WM and others},
+  journal={Scientific Data},
+  year={2022},
+  url={https://doi.org/10.1038/s41597-022-01231-7},
+  doi={10.1038/s41597-022-01231-7},
+  abstract={Central to understanding human behavior is a comprehensive mapping of brain-behavior relations within the context of lifespan development. Reproducible discoveries depend upon well-powered samples of reliable data. We provide to the scientific community two, 10-minute, multi-echo functional MRI (ME-fMRI) runs, and structural MRI (T1-MPRAGE), from 181 healthy younger (ages 18–34 y) and 120 older adults (ages 60–89 y). T2-FLAIR MRIs and behavioral assessments are available in a majority subset of over 250 participants. Behavioral assessments include fluid and crystallized cognition, self-reported measures of personality, and socioemotional functioning. Initial quality control and validation of these data is provided. This dataset will be of value to scientists interested in BOLD signal specifically isolated from ME-fMRI, individual differences in brain-behavioral associations, and cross-sectional aging effects in healthy adults. Demographic and behavioral data are available within the Open Science Framework project “Goal-Directed Cognition in Older and Younger Adults” (http://osf.io/yhzxe/), which will be augmented over time; neuroimaging data are available on OpenNeuro (https://openneuro.org/datasets/ds003592)}
+}
+
 @article{van2023framewise,
   title={Framewise multi-echo distortion correction for superior functional MRI},
   author={Van, Andrew N and Montez, David F and Laumann, Timothy O and Suljic, Vahdeta and Madison, Thomas and Baden, Noah J and Ramirez-Perez, Nadeshka and Scheidter, Kristen M and Monk, Julia S and Whiting, Forrest I and others},
   journal={Biorxiv},
   year={2023},
   publisher={Cold Spring Harbor Laboratory Preprints}
+}
+
+@article{vizioli2021lowering,
+  title={Lowering the thermal noise barrier in functional brain mapping with magnetic resonance imaging},
+  author={Vizioli, Luca and Moeller, Steen and Dowdle, Logan and Ak{\c{c}}akaya, Mehmet and De Martino, Federico and Yacoub, Essa and U{\u{g}}urbil, Kamil},
+  journal={Nature communications},
+  volume={12},
+  number={1},
+  pages={5181},
+  year={2021},
+  publisher={Nature Publishing Group UK London}
 }


### PR DESCRIPTION
I was putting together some of this reading list and history info for my OHBM talk and may want to link to an expanded version.

I also added references to `references.bib` and alphabetized that file to make it easier to avoid re-adding existing references.

I was having some issues with local files being committed so I added info to `.gitignore` It might have been files from a previous version of this book so the alteration might not have been necessary.