### PR TITLE
Fix Acquiring Multi-Echo Data build: select TR column by prefix

### DIFF
--- a/content/Acquiring_Multi_Echo_Data.md
+++ b/content/Acquiring_Multi_Echo_Data.md
@@ -274,9 +274,17 @@ plt.show()
 
 # The TR column header carries its unit and has been renamed before
 # ("TR" -> "TR (s)"), so match it by prefix instead of hard-coding the name.
-# Columns can also come back as object dtype when the source spreadsheet has
-# blank or non-numeric cells; coerce to float and drop NaNs before plotting.
-tr_col = next(c for c in metable.columns if c.strip().startswith("TR"))
+# Fail with a clear message if the header drifts to zero or several matches,
+# rather than raising an opaque StopIteration mid-build.
+tr_matches = [c for c in metable.columns if c.strip().startswith("TR")]
+if len(tr_matches) != 1:
+    raise ValueError(
+        f"Expected exactly one 'TR' column in the study-parameters sheet, "
+        f"found {tr_matches!r}; update the column selection in this cell."
+    )
+tr_col = tr_matches[0]
+# Columns can come back as object dtype when the source spreadsheet has blank
+# or non-numeric cells; coerce to float and drop NaNs before plotting.
 tr = pd.to_numeric(metable[tr_col], errors="coerce").dropna().to_numpy()
 plt.hist(tr)
 plt.title("Repetition Times", fontsize=18)

--- a/content/Acquiring_Multi_Echo_Data.md
+++ b/content/Acquiring_Multi_Echo_Data.md
@@ -272,9 +272,12 @@ axes[0].set_ylabel("Echo Time (ms)")
 fig.tight_layout()
 plt.show()
 
-# Columns can come back as object dtype when the source spreadsheet has blank
-# or non-numeric cells; coerce to float and drop NaNs before plotting.
-tr = pd.to_numeric(metable.TR, errors="coerce").dropna().to_numpy()
+# The TR column header carries its unit and has been renamed before
+# ("TR" -> "TR (s)"), so match it by prefix instead of hard-coding the name.
+# Columns can also come back as object dtype when the source spreadsheet has
+# blank or non-numeric cells; coerce to float and drop NaNs before plotting.
+tr_col = next(c for c in metable.columns if c.strip().startswith("TR"))
+tr = pd.to_numeric(metable[tr_col], errors="coerce").dropna().to_numpy()
 plt.hist(tr)
 plt.title("Repetition Times", fontsize=18)
 plt.xlabel("Repetition Time (s)")


### PR DESCRIPTION
## Problem

The study-parameters Google Sheet linked from the **ME-fMRI parameters** section renamed its repetition-time column from `TR` to `TR (s)`. The code cell in `content/Acquiring_Multi_Echo_Data.md` accessed it as `metable.TR`, which now raises:

```
AttributeError: 'DataFrame' object has no attribute 'TR'
```

This breaks execution of the page during `jupyter-book build` (it surfaced in the full build for #73, but is unrelated to that work — hence this standalone PR).

## Fix

Select the TR column by prefix instead of hard-coding the name, so a future unit-suffix tweak (`TR` → `TR (s)` → …) won't break the cell again:

```python
tr_col = next(c for c in metable.columns if c.strip().startswith("TR"))
tr = pd.to_numeric(metable[tr_col], errors="coerce").dropna().to_numpy()
```

Verified against the live sheet that `x`/`y`/`z` and `TE1`–`TE6` still match the header, so those references are untouched.

## Verification

`UV_PROJECT_ENVIRONMENT=meda uv run --locked jupyter-book build ./` succeeds; the page now executes:

```
content/Acquiring_Multi_Echo_Data.md: Executed notebook in 3.01 seconds [mystnb]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)